### PR TITLE
Fix tools failure on macOS

### DIFF
--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -9,13 +9,29 @@ error() {
   echo "[tools] $*" >&2
 }
 
-declare -A TOOL_DOCS=(
-  [kind]="https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
-  [kubectl]="https://kubernetes.io/docs/tasks/tools/"
-  [helm]="https://helm.sh/docs/intro/install/"
-  [jq]="https://jqlang.github.io/jq/download/"
-  [openssl]="https://www.openssl.org/source/"
-)
+get_tool_docs() {
+  local name="$1"
+  case "${name}" in
+    kind)
+      echo "https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
+      ;;
+    kubectl)
+      echo "https://kubernetes.io/docs/tasks/tools/"
+      ;;
+    helm)
+      echo "https://helm.sh/docs/intro/install/"
+      ;;
+    jq)
+      echo "https://jqlang.github.io/jq/download/"
+      ;;
+    openssl)
+      echo "https://www.openssl.org/source/"
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
 
 print_version() {
   local name="$1"
@@ -60,7 +76,9 @@ check_tool() {
     return 0
   fi
 
-  error "missing ${name}. Install instructions: ${TOOL_DOCS[$name]}"
+  local docs_url
+  docs_url="$(get_tool_docs "${name}")"
+  error "missing ${name}. Install instructions: ${docs_url}"
   return 1
 }
 


### PR DESCRIPTION
Fix `make tools` failure on macOS by replacing bash associative arrays with a `case` statement.

The default bash version on macOS (3.2) does not support associative arrays (`declare -A`), causing the `install-tools.sh` script to fail. This change ensures compatibility with older bash versions, allowing `make tools` to run successfully on macOS without requiring a bash upgrade.

---
<a href="https://cursor.com/background-agent?bcId=bc-c64fe9f6-733b-4412-a2e6-1512756e3d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c64fe9f6-733b-4412-a2e6-1512756e3d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

