### PR TITLE
Remove hostNetwork from spire-agent DaemonSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ This target:
   - Kubernetes node attestation (k8s_psat plugin)
   - Workload API socket at `/run/spire/sockets/workload_api.sock`
   - Proper RBAC (ClusterRole and ClusterRoleBinding) for node attestation
-  - Host network mode for socket access
 - Waits for all agent pods to be ready before returning
 
 The deployment is **idempotent**: safe to run multiple times.

--- a/deploy/spire/agent/daemonset.yaml
+++ b/deploy/spire/agent/daemonset.yaml
@@ -15,9 +15,7 @@ spec:
         app: spire-agent
     spec:
       serviceAccountName: spire-agent
-      hostNetwork: true
       hostPID: true
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: spire-agent
         image: ghcr.io/spiffe/spire-agent:1.13.0


### PR DESCRIPTION
Addresses #24

This PR removes the `hostNetwork: true` configuration from the spire-agent DaemonSet as it's not needed for the test cluster.

## Changes
- Removed `hostNetwork: true` from `deploy/spire/agent/daemonset.yaml`
- Removed `dnsPolicy: ClusterFirstWithHostNet` (defaults to `ClusterFirst`)
- Kept `hostPID: true` as it's needed for process attestation
- Updated README.md to remove mention of host network mode

## Testing
✅ Full deployment tested from scratch:
- Cluster created successfully
- SPIRE server deployed and healthy
- SPIRE agent DaemonSet deployed with 3 pods, all healthy
- All agents successfully attested with server
- Workload API socket accessible via hostPath mount
- Health checks passing

The Workload API socket remains accessible to workloads via the hostPath volume mount at `/run/spire/sockets`, so removing hostNetwork does not break functionality.