### PR TITLE
Add colorful output and Makefile orchestration targets (Issue #12)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 ROOT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 TOOLS_SCRIPT := $(ROOT_DIR)/scripts/install-tools.sh
 CERT_SCRIPT := $(ROOT_DIR)/scripts/generate-certs.sh
+CLUSTER_UP_SCRIPT := $(ROOT_DIR)/scripts/cluster-up.sh
 DEPLOY_SPIRE_SCRIPT := $(ROOT_DIR)/scripts/deploy-spire-server.sh
 UNDEPLOY_SPIRE_SCRIPT := $(ROOT_DIR)/scripts/undeploy-spire-server.sh
 CHECK_SPIRE_SCRIPT := $(ROOT_DIR)/scripts/check-spire-server.sh
@@ -18,6 +19,29 @@ BOOTSTRAP_BUNDLE := $(CERT_DIR)/bootstrap-bundle.pem
 SPIRE_AGENT_DIR := $(ROOT_DIR)/deploy/spire/agent
 KUBECTL := KUBECONFIG="$(KUBECONFIG_PATH)" kubectl
 
+# Color definitions (only if output is a TTY)
+ifneq ($(shell [ -t 1 ] && echo yes),)
+  COLOR_RESET := \033[0m
+  COLOR_BOLD := \033[1m
+  COLOR_RED := \033[0;31m
+  COLOR_GREEN := \033[0;32m
+  COLOR_YELLOW := \033[0;33m
+  COLOR_BLUE := \033[0;34m
+  COLOR_CYAN := \033[0;36m
+  COLOR_BRIGHT_GREEN := \033[1;32m
+  COLOR_BRIGHT_BLUE := \033[1;34m
+else
+  COLOR_RESET :=
+  COLOR_BOLD :=
+  COLOR_RED :=
+  COLOR_GREEN :=
+  COLOR_YELLOW :=
+  COLOR_BLUE :=
+  COLOR_CYAN :=
+  COLOR_BRIGHT_GREEN :=
+  COLOR_BRIGHT_BLUE :=
+endif
+
 .PHONY: tools
 tools:
 	@$(TOOLS_SCRIPT)
@@ -28,33 +52,25 @@ certs:
 
 .PHONY: clean
 clean:
-	@echo "[clean] Removing generated certificates..."
-	@rm -rf $(CERT_DIR)
-	@echo "[clean] Clean complete."
+	@echo "$(COLOR_CYAN)[clean]$(COLOR_RESET) Removing generated artifacts..."
+	@rm -rf $(ARTIFACTS_DIR)
+	@if [ -d "$(ROOT_DIR)/bin" ]; then \
+		echo "$(COLOR_CYAN)[clean]$(COLOR_RESET) Removing binaries..."; \
+		rm -rf "$(ROOT_DIR)/bin"; \
+	fi
+	@echo "$(COLOR_GREEN)[clean]$(COLOR_RESET) Clean complete."
 
 .PHONY: cluster-up
 cluster-up: $(KIND_CONFIG)
-	@mkdir -p "$(ARTIFACTS_DIR)"
-	@if $(KIND) get clusters | grep -qx "$(KIND_CLUSTER_NAME)"; then \
-		echo "kind cluster '$(KIND_CLUSTER_NAME)' already exists"; \
-	else \
-		echo "Creating kind cluster '$(KIND_CLUSTER_NAME)'"; \
-		KUBECONFIG="$(KUBECONFIG_PATH)" $(KIND) create cluster --name "$(KIND_CLUSTER_NAME)" --config "$(KIND_CONFIG)"; \
-	fi
-	@$(KIND) get kubeconfig --name "$(KIND_CLUSTER_NAME)" > "$(KUBECONFIG_PATH)"
-	@echo "Kubeconfig written to $(KUBECONFIG_PATH)"
-	@echo "Deploying httpbin service..."
-	@KUBECONFIG="$(KUBECONFIG_PATH)" $(KUBECTL) apply -f "$(ROOT_DIR)/deploy/httpbin/httpbin.yaml" || true
-	@echo "Waiting for httpbin pod to be ready..."
-	@KUBECONFIG="$(KUBECONFIG_PATH)" $(KUBECTL) wait --for=condition=ready pod -l app=httpbin -n httpbin --timeout=60s 2>/dev/null || echo "httpbin deployment may still be in progress"
+	@KIND="$(KIND)" KIND_CLUSTER_NAME="$(KIND_CLUSTER_NAME)" KIND_CONFIG="$(KIND_CONFIG)" ARTIFACTS_DIR="$(ARTIFACTS_DIR)" KUBECONFIG_PATH="$(KUBECONFIG_PATH)" ROOT_DIR="$(ROOT_DIR)" $(CLUSTER_UP_SCRIPT)
 
 .PHONY: cluster-down
 cluster-down:
 	@if $(KIND) get clusters | grep -qx "$(KIND_CLUSTER_NAME)"; then \
-		echo "Deleting kind cluster '$(KIND_CLUSTER_NAME)'"; \
+		echo "$(COLOR_CYAN)[cluster-down]$(COLOR_RESET) Deleting kind cluster '$(COLOR_BOLD)$(KIND_CLUSTER_NAME)$(COLOR_RESET)'"; \
 		$(KIND) delete cluster --name "$(KIND_CLUSTER_NAME)"; \
 	else \
-		echo "kind cluster '$(KIND_CLUSTER_NAME)' already absent"; \
+		echo "$(COLOR_YELLOW)[cluster-down]$(COLOR_RESET) kind cluster '$(COLOR_BOLD)$(KIND_CLUSTER_NAME)$(COLOR_RESET)' already absent"; \
 	fi
 	@rm -f "$(KUBECONFIG_PATH)"
 	@if [ -d "$(ARTIFACTS_DIR)" ] && [ -z "$$(ls -A "$(ARTIFACTS_DIR)")" ]; then rmdir "$(ARTIFACTS_DIR)"; fi
@@ -63,15 +79,15 @@ cluster-down:
 .PHONY: check-cluster
 check-cluster:
 	@if ! $(KIND) get clusters | grep -qx "$(KIND_CLUSTER_NAME)"; then \
-		echo "Error: kind cluster '$(KIND_CLUSTER_NAME)' does not exist. Run 'make cluster-up' first."; \
+		echo "$(COLOR_RED)[check-cluster] Error:$(COLOR_RESET) kind cluster '$(COLOR_BOLD)$(KIND_CLUSTER_NAME)$(COLOR_RESET)' does not exist. Run 'make cluster-up' first."; \
 		exit 1; \
 	fi
 	@if [ ! -f "$(KUBECONFIG_PATH)" ]; then \
-		echo "Error: kubeconfig not found at $(KUBECONFIG_PATH). Run 'make cluster-up' first."; \
+		echo "$(COLOR_RED)[check-cluster] Error:$(COLOR_RESET) kubeconfig not found at $(COLOR_CYAN)$(KUBECONFIG_PATH)$(COLOR_RESET). Run 'make cluster-up' first."; \
 		exit 1; \
 	fi
 	@if ! $(KUBECTL) cluster-info > /dev/null 2>&1; then \
-		echo "Error: unable to connect to cluster. Run 'make cluster-up' first."; \
+		echo "$(COLOR_RED)[check-cluster] Error:$(COLOR_RESET) unable to connect to cluster. Run 'make cluster-up' first."; \
 		exit 1; \
 	fi
 
@@ -79,18 +95,18 @@ check-cluster:
 .PHONY: check-certs
 check-certs:
 	@if [ ! -f "$(CERT_DIR)/ca-cert.pem" ] || [ ! -f "$(CERT_DIR)/ca-key.pem" ]; then \
-		echo "Error: CA certificate files not found. Expected: $(CERT_DIR)/ca-cert.pem, $(CERT_DIR)/ca-key.pem"; \
-		echo "Run 'make certs' first."; \
+		echo "$(COLOR_RED)[check-certs] Error:$(COLOR_RESET) CA certificate files not found. Expected: $(COLOR_CYAN)$(CERT_DIR)/ca-cert.pem$(COLOR_RESET), $(COLOR_CYAN)$(CERT_DIR)/ca-key.pem$(COLOR_RESET)"; \
+		echo "$(COLOR_YELLOW)[check-certs]$(COLOR_RESET) Run 'make certs' first."; \
 		exit 1; \
 	fi
 	@if [ ! -f "$(CERT_DIR)/spire-server-cert.pem" ] || [ ! -f "$(CERT_DIR)/spire-server-key.pem" ]; then \
-		echo "Error: SPIRE server certificate files not found. Expected: $(CERT_DIR)/spire-server-cert.pem, $(CERT_DIR)/spire-server-key.pem"; \
-		echo "Run 'make certs' first."; \
+		echo "$(COLOR_RED)[check-certs] Error:$(COLOR_RESET) SPIRE server certificate files not found. Expected: $(COLOR_CYAN)$(CERT_DIR)/spire-server-cert.pem$(COLOR_RESET), $(COLOR_CYAN)$(CERT_DIR)/spire-server-key.pem$(COLOR_RESET)"; \
+		echo "$(COLOR_YELLOW)[check-certs]$(COLOR_RESET) Run 'make certs' first."; \
 		exit 1; \
 	fi
 	@if [ ! -f "$(CERT_DIR)/bootstrap-bundle.pem" ]; then \
-		echo "Error: Bootstrap bundle not found. Expected: $(CERT_DIR)/bootstrap-bundle.pem"; \
-		echo "Run 'make certs' first."; \
+		echo "$(COLOR_RED)[check-certs] Error:$(COLOR_RESET) Bootstrap bundle not found. Expected: $(COLOR_CYAN)$(CERT_DIR)/bootstrap-bundle.pem$(COLOR_RESET)"; \
+		echo "$(COLOR_YELLOW)[check-certs]$(COLOR_RESET) Run 'make certs' first."; \
 		exit 1; \
 	fi
 
@@ -121,3 +137,12 @@ deploy-registration: check-cluster
 .PHONY: undeploy-registration
 undeploy-registration:
 	@$(UNDEPLOY_REGISTRATION_SCRIPT)
+
+# Top-level orchestration targets
+.PHONY: env-up
+env-up: tools certs cluster-up deploy-spire-server deploy-spire-agent deploy-registration
+	@echo "$(COLOR_BRIGHT_GREEN)[env-up]$(COLOR_RESET) $(COLOR_BOLD)Environment setup complete!$(COLOR_RESET)"
+
+.PHONY: env-down
+env-down: undeploy-registration undeploy-spire-agent undeploy-spire-server cluster-down clean
+	@echo "$(COLOR_BRIGHT_GREEN)[env-down]$(COLOR_RESET) $(COLOR_BOLD)Environment teardown complete!$(COLOR_RESET)"

--- a/scripts/check-spire-server.sh
+++ b/scripts/check-spire-server.sh
@@ -1,42 +1,47 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Source color support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/colors.sh"
+
 ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/artifacts/kubeconfig}"
 
 export KUBECONFIG="${KUBECONFIG_PATH}"
 
-echo "[check] Checking SPIRE server status..."
+echo -e "${COLOR_BRIGHT_BLUE}[check-spire-server]${COLOR_RESET} ${COLOR_BOLD}Checking SPIRE server status...${COLOR_RESET}"
 echo ""
-echo "=== Pod Status ==="
+
+echo -e "${COLOR_CYAN}[check-spire-server]${COLOR_RESET} ${COLOR_BOLD}=== Pod Status ===${COLOR_RESET}"
 if ! kubectl get pods -n spire-server -l app=spire-server; then
-	echo "Error: SPIRE server namespace or pods not found. Run 'make deploy-spire-server' first."
+	echo -e "${COLOR_RED}[check-spire-server] Error:${COLOR_RESET} SPIRE server namespace or pods not found. Run 'make deploy-spire-server' first."
 	exit 1
 fi
 
 echo ""
-echo "=== Service Status ==="
-kubectl get svc -n spire-server spire-server || echo "Service not found"
+echo -e "${COLOR_CYAN}[check-spire-server]${COLOR_RESET} ${COLOR_BOLD}=== Service Status ===${COLOR_RESET}"
+kubectl get svc -n spire-server spire-server || echo -e "${COLOR_YELLOW}[check-spire-server]${COLOR_RESET} Service not found"
 
 echo ""
-echo "=== Pod Logs (last 20 lines) ==="
-kubectl logs -n spire-server -l app=spire-server --tail=20 || echo "Unable to fetch logs"
+echo -e "${COLOR_CYAN}[check-spire-server]${COLOR_RESET} ${COLOR_BOLD}=== Pod Logs (last 20 lines) ===${COLOR_RESET}"
+kubectl logs -n spire-server -l app=spire-server --tail=20 || echo -e "${COLOR_YELLOW}[check-spire-server]${COLOR_RESET} Unable to fetch logs"
 
 echo ""
-echo "=== Health Check ==="
+echo -e "${COLOR_CYAN}[check-spire-server]${COLOR_RESET} ${COLOR_BOLD}=== Health Check ===${COLOR_RESET}"
 if kubectl get pod -n spire-server -l app=spire-server -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}' | grep -q "True"; then
-	echo "✓ SPIRE server pod is Ready"
+	echo -e "${COLOR_GREEN}✓${COLOR_RESET} SPIRE server pod is Ready"
 else
-	echo "✗ SPIRE server pod is not Ready"
+	echo -e "${COLOR_RED}✗${COLOR_RESET} SPIRE server pod is not Ready"
 fi
 
 if kubectl get pod -n spire-server -l app=spire-server -o jsonpath='{.items[0].status.containerStatuses[0].ready}' | grep -q "true"; then
-	echo "✓ SPIRE server container is ready"
+	echo -e "${COLOR_GREEN}✓${COLOR_RESET} SPIRE server container is ready"
 else
-	echo "✗ SPIRE server container is not ready"
+	echo -e "${COLOR_RED}✗${COLOR_RESET} SPIRE server container is not ready"
 fi
 
 echo ""
-echo "To view full logs: kubectl logs -n spire-server -l app=spire-server -f"
-echo "To exec into pod: kubectl exec -it -n spire-server -l app=spire-server -- /bin/sh"
+echo -e "${COLOR_CYAN}[check-spire-server]${COLOR_RESET} To view full logs: ${COLOR_BOLD}kubectl logs -n spire-server -l app=spire-server -f${COLOR_RESET}"
+echo -e "${COLOR_CYAN}[check-spire-server]${COLOR_RESET} To exec into pod: ${COLOR_BOLD}kubectl exec -it -n spire-server -l app=spire-server -- /bin/sh${COLOR_RESET}"
 

--- a/scripts/cluster-up.sh
+++ b/scripts/cluster-up.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source color support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/colors.sh"
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+KIND="${KIND:-kind}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-spiffe-helper}"
+KIND_CONFIG="${KIND_CONFIG:-${ROOT_DIR}/kind-config.yaml}"
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-${ROOT_DIR}/artifacts}"
+KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ARTIFACTS_DIR}/kubeconfig}"
+
+# Create artifacts directory
+mkdir -p "${ARTIFACTS_DIR}"
+
+echo -e "${COLOR_BRIGHT_BLUE}[cluster-up]${COLOR_RESET} ${COLOR_BOLD}Setting up kind cluster...${COLOR_RESET}"
+
+# Check if cluster already exists
+if ${KIND} get clusters | grep -qx "${KIND_CLUSTER_NAME}"; then
+	echo -e "${COLOR_YELLOW}[cluster-up]${COLOR_RESET} kind cluster '${COLOR_BOLD}${KIND_CLUSTER_NAME}${COLOR_RESET}' already exists"
+else
+	echo -e "${COLOR_CYAN}[cluster-up]${COLOR_RESET} Creating kind cluster '${COLOR_BOLD}${KIND_CLUSTER_NAME}${COLOR_RESET}'..."
+	KUBECONFIG="${KUBECONFIG_PATH}" ${KIND} create cluster --name "${KIND_CLUSTER_NAME}" --config "${KIND_CONFIG}"
+fi
+
+# Get kubeconfig
+echo -e "${COLOR_CYAN}[cluster-up]${COLOR_RESET} Writing kubeconfig..."
+${KIND} get kubeconfig --name "${KIND_CLUSTER_NAME}" > "${KUBECONFIG_PATH}"
+echo -e "${COLOR_GREEN}✓${COLOR_RESET} Kubeconfig written to ${COLOR_CYAN}${KUBECONFIG_PATH}${COLOR_RESET}"
+
+# Deploy httpbin service
+echo -e "${COLOR_CYAN}[cluster-up]${COLOR_RESET} Deploying httpbin service..."
+export KUBECONFIG="${KUBECONFIG_PATH}"
+if kubectl apply -f "${ROOT_DIR}/deploy/httpbin/httpbin.yaml" 2>/dev/null; then
+	echo -e "${COLOR_CYAN}[cluster-up]${COLOR_RESET} Waiting for httpbin pod to be ready..."
+	if kubectl wait --for=condition=ready pod -l app=httpbin -n httpbin --timeout=60s 2>/dev/null; then
+		echo -e "${COLOR_GREEN}✓${COLOR_RESET} httpbin pod is ready"
+	else
+		echo -e "${COLOR_YELLOW}[cluster-up]${COLOR_RESET} httpbin deployment may still be in progress"
+	fi
+else
+	echo -e "${COLOR_YELLOW}[cluster-up]${COLOR_RESET} Failed to deploy httpbin (may already exist)"
+fi
+
+echo ""
+echo -e "${COLOR_BRIGHT_GREEN}[cluster-up]${COLOR_RESET} ${COLOR_BOLD}Cluster setup complete!${COLOR_RESET}"

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Color support for scripts
+# Usage: source this file in your script
+
+# Check if output is a TTY (terminal)
+if [[ -t 1 ]]; then
+  # Colors enabled
+  COLOR_RESET='\033[0m'
+  COLOR_BOLD='\033[1m'
+  
+  # Standard colors
+  COLOR_RED='\033[0;31m'
+  COLOR_GREEN='\033[0;32m'
+  COLOR_YELLOW='\033[0;33m'
+  COLOR_BLUE='\033[0;34m'
+  COLOR_MAGENTA='\033[0;35m'
+  COLOR_CYAN='\033[0;36m'
+  COLOR_WHITE='\033[0;37m'
+  
+  # Bright colors
+  COLOR_BRIGHT_RED='\033[1;31m'
+  COLOR_BRIGHT_GREEN='\033[1;32m'
+  COLOR_BRIGHT_YELLOW='\033[1;33m'
+  COLOR_BRIGHT_BLUE='\033[1;34m'
+  COLOR_BRIGHT_MAGENTA='\033[1;35m'
+  COLOR_BRIGHT_CYAN='\033[1;36m'
+else
+  # Colors disabled (piping, redirecting, etc.)
+  COLOR_RESET=''
+  COLOR_BOLD=''
+  COLOR_RED=''
+  COLOR_GREEN=''
+  COLOR_YELLOW=''
+  COLOR_BLUE=''
+  COLOR_MAGENTA=''
+  COLOR_CYAN=''
+  COLOR_WHITE=''
+  COLOR_BRIGHT_RED=''
+  COLOR_BRIGHT_GREEN=''
+  COLOR_BRIGHT_YELLOW=''
+  COLOR_BRIGHT_BLUE=''
+  COLOR_BRIGHT_MAGENTA=''
+  COLOR_BRIGHT_CYAN=''
+fi
+
+# Color functions for common use cases
+color_info() {
+  echo -e "${COLOR_CYAN}[info]${COLOR_RESET} $*"
+}
+
+color_success() {
+  echo -e "${COLOR_GREEN}[success]${COLOR_RESET} $*"
+}
+
+color_warning() {
+  echo -e "${COLOR_YELLOW}[warning]${COLOR_RESET} $*" >&2
+}
+
+color_error() {
+  echo -e "${COLOR_RED}[error]${COLOR_RESET} $*" >&2
+}
+
+color_header() {
+  echo -e "${COLOR_BOLD}${COLOR_BRIGHT_BLUE}$*${COLOR_RESET}"
+}
+
+color_step() {
+  echo -e "${COLOR_BOLD}${COLOR_CYAN}→${COLOR_RESET} $*"
+}
+
+color_ok() {
+  echo -e "${COLOR_GREEN}✓${COLOR_RESET} $*"
+}
+
+color_fail() {
+  echo -e "${COLOR_RED}✗${COLOR_RESET} $*"
+}

--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Source color support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/colors.sh"
+
 info() {
-  echo "[certs] $*"
+  echo -e "${COLOR_CYAN}[certs]${COLOR_RESET} $*"
 }
 
 error() {
-  echo "[certs] $*" >&2
+  echo -e "${COLOR_RED}[certs]${COLOR_RESET} $*" >&2
 }
 
 # Default values
@@ -38,37 +42,37 @@ file_exists() {
 # Function to generate CA certificate and key
 generate_ca() {
   if [[ "${FORCE}" -eq 0 ]] && file_exists "${CA_KEY}" && file_exists "${CA_CERT}"; then
-    info "CA certificate and key already exist, skipping generation"
+    echo -e "${COLOR_YELLOW}[certs]${COLOR_RESET} CA certificate and key already exist, skipping generation"
     return 0
   fi
 
-  info "Generating CA private key (ECDSA P-384) in PKCS#8 format..."
+  echo -e "${COLOR_CYAN}[certs]${COLOR_RESET} Generating CA private key ${COLOR_BOLD}(ECDSA P-384)${COLOR_RESET} in PKCS#8 format..."
   openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:secp384r1 -out "${CA_KEY}"
 
-  info "Generating CA certificate..."
+  echo -e "${COLOR_CYAN}[certs]${COLOR_RESET} Generating CA certificate..."
   openssl req -new -x509 -days 3650 -key "${CA_KEY}" -out "${CA_CERT}" \
     -subj "/CN=spiffe-helper-sandbox-ca" \
     -addext "basicConstraints=critical,CA:TRUE" \
     -addext "keyUsage=critical,keyCertSign,cRLSign"
 
-  info "CA certificate and key generated successfully"
+  echo -e "${COLOR_GREEN}✓${COLOR_RESET} CA certificate and key generated successfully"
 }
 
 # Function to generate SPIRE server certificate and key
 generate_spire_server() {
   if [[ "${FORCE}" -eq 0 ]] && file_exists "${SERVER_KEY}" && file_exists "${SERVER_CERT}"; then
-    info "SPIRE server certificate and key already exist, skipping generation"
+    echo -e "${COLOR_YELLOW}[certs]${COLOR_RESET} SPIRE server certificate and key already exist, skipping generation"
     return 0
   fi
 
-  info "Generating SPIRE server private key (ECDSA P-256) in PKCS#8 format..."
+  echo -e "${COLOR_CYAN}[certs]${COLOR_RESET} Generating SPIRE server private key ${COLOR_BOLD}(ECDSA P-256)${COLOR_RESET} in PKCS#8 format..."
   openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:prime256v1 -out "${SERVER_KEY}"
 
-  info "Generating SPIRE server certificate signing request..."
+  echo -e "${COLOR_CYAN}[certs]${COLOR_RESET} Generating SPIRE server certificate signing request..."
   openssl req -new -key "${SERVER_KEY}" -out "${SERVER_CSR}" \
     -subj "/CN=spiffe-helper-sandbox-spire-server"
 
-  info "Generating SPIRE server certificate (signed by CA)..."
+  echo -e "${COLOR_CYAN}[certs]${COLOR_RESET} Generating SPIRE server certificate ${COLOR_BOLD}(signed by CA)${COLOR_RESET}..."
   openssl x509 -req -in "${SERVER_CSR}" -CA "${CA_CERT}" -CAkey "${CA_KEY}" \
     -CAcreateserial -out "${SERVER_CERT}" -days 365 \
     -extensions v3_server -extfile <(
@@ -79,13 +83,13 @@ generate_spire_server() {
       echo "subjectAltName=DNS:spire-server,DNS:spire-server.default.svc.cluster.local"
     )
 
-  info "SPIRE server certificate and key generated successfully"
+  echo -e "${COLOR_GREEN}✓${COLOR_RESET} SPIRE server certificate and key generated successfully"
 }
 
 # Function to generate bootstrap bundle
 generate_bootstrap_bundle() {
   if [[ "${FORCE}" -eq 0 ]] && file_exists "${BOOTSTRAP_BUNDLE}"; then
-    info "Bootstrap bundle already exists, skipping generation"
+    echo -e "${COLOR_YELLOW}[certs]${COLOR_RESET} Bootstrap bundle already exists, skipping generation"
     return 0
   fi
 
@@ -94,26 +98,27 @@ generate_bootstrap_bundle() {
     exit 1
   fi
 
-  info "Generating bootstrap bundle..."
+  echo -e "${COLOR_CYAN}[certs]${COLOR_RESET} Generating bootstrap bundle..."
   cp "${CA_CERT}" "${BOOTSTRAP_BUNDLE}"
 
-  info "Bootstrap bundle generated successfully"
+  echo -e "${COLOR_GREEN}✓${COLOR_RESET} Bootstrap bundle generated successfully"
 }
 
 main() {
-  info "Starting certificate generation..."
-  info "Output directory: ${CERT_DIR}"
+  echo -e "${COLOR_BRIGHT_BLUE}[certs]${COLOR_RESET} ${COLOR_BOLD}Starting certificate generation...${COLOR_RESET}"
+  echo -e "${COLOR_CYAN}[certs]${COLOR_RESET} Output directory: ${COLOR_BOLD}${CERT_DIR}${COLOR_RESET}"
 
   generate_ca
   generate_spire_server
   generate_bootstrap_bundle
 
-  info "Certificate generation complete!"
-  info ""
-  info "Generated files:"
-  info "  - CA: ${CA_KEY}, ${CA_CERT}"
-  info "  - SPIRE Server: ${SERVER_KEY}, ${SERVER_CERT}, ${SERVER_CSR}"
-  info "  - Bootstrap Bundle: ${BOOTSTRAP_BUNDLE}"
+  echo ""
+  echo -e "${COLOR_BRIGHT_GREEN}[certs]${COLOR_RESET} ${COLOR_BOLD}Certificate generation complete!${COLOR_RESET}"
+  echo ""
+  echo -e "${COLOR_CYAN}[certs]${COLOR_RESET} Generated files:"
+  echo -e "  ${COLOR_GREEN}✓${COLOR_RESET} CA: ${COLOR_CYAN}${CA_KEY}${COLOR_RESET}, ${COLOR_CYAN}${CA_CERT}${COLOR_RESET}"
+  echo -e "  ${COLOR_GREEN}✓${COLOR_RESET} SPIRE Server: ${COLOR_CYAN}${SERVER_KEY}${COLOR_RESET}, ${COLOR_CYAN}${SERVER_CERT}${COLOR_RESET}, ${COLOR_CYAN}${SERVER_CSR}${COLOR_RESET}"
+  echo -e "  ${COLOR_GREEN}✓${COLOR_RESET} Bootstrap Bundle: ${COLOR_CYAN}${BOOTSTRAP_BUNDLE}${COLOR_RESET}"
 }
 
 main "$@"

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Source color support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/colors.sh"
+
 info() {
-  echo "[tools] $*"
+  echo -e "${COLOR_CYAN}[tools]${COLOR_RESET} $*"
 }
 
 error() {
-  echo "[tools] $*" >&2
+  echo -e "${COLOR_RED}[tools]${COLOR_RESET} $*" >&2
 }
 
 get_tool_docs() {
@@ -69,16 +73,17 @@ check_tool() {
   if command -v "${name}" >/dev/null 2>&1; then
     local version_info
     if version_info="$(print_version "${name}")"; then
-      info "found ${name}: ${version_info}"
+      echo -e "${COLOR_GREEN}✓${COLOR_RESET} ${COLOR_BOLD}${name}${COLOR_RESET}: ${COLOR_CYAN}${version_info}${COLOR_RESET}"
     else
-      info "found ${name}"
+      echo -e "${COLOR_GREEN}✓${COLOR_RESET} ${COLOR_BOLD}${name}${COLOR_RESET}"
     fi
     return 0
   fi
 
   local docs_url
   docs_url="$(get_tool_docs "${name}")"
-  error "missing ${name}. Install instructions: ${docs_url}"
+  echo -e "${COLOR_RED}✗${COLOR_RESET} ${COLOR_BOLD}${name}${COLOR_RESET} ${COLOR_RED}missing${COLOR_RESET}"
+  echo -e "  ${COLOR_YELLOW}Install instructions:${COLOR_RESET} ${COLOR_CYAN}${docs_url}${COLOR_RESET}" >&2
   return 1
 }
 
@@ -91,12 +96,13 @@ main() {
   done
 
   if [[ "${missing}" -eq 1 ]]; then
-    error ""
+    echo ""
     error "Install the missing tool(s) and re-run 'make tools'."
     exit 1
   fi
 
-  info "all required tools are available."
+  echo ""
+  echo -e "${COLOR_BRIGHT_GREEN}[tools]${COLOR_RESET} ${COLOR_BOLD}All required tools are available!${COLOR_RESET}"
 }
 
 main "$@"

--- a/scripts/undeploy-spire-agent.sh
+++ b/scripts/undeploy-spire-agent.sh
@@ -1,24 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Source color support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/colors.sh"
+
 ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/artifacts/kubeconfig}"
 
 export KUBECONFIG="${KUBECONFIG_PATH}"
 
-echo "[undeploy-spire-agent] Removing SPIRE agent..."
+echo -e "${COLOR_BRIGHT_BLUE}[undeploy-spire-agent]${COLOR_RESET} ${COLOR_BOLD}Removing SPIRE agent...${COLOR_RESET}"
 
 if [ ! -f "${KUBECONFIG_PATH}" ]; then
-	echo "Kubeconfig not found. Skipping undeploy."
+	echo -e "${COLOR_YELLOW}[undeploy-spire-agent]${COLOR_RESET} Kubeconfig not found. Skipping undeploy."
 	exit 0
 fi
 
+echo -e "${COLOR_CYAN}[undeploy-spire-agent]${COLOR_RESET} Deleting DaemonSet..."
 kubectl delete daemonset spire-agent -n spire-agent --ignore-not-found=true
+echo -e "${COLOR_CYAN}[undeploy-spire-agent]${COLOR_RESET} Deleting ConfigMap..."
 kubectl delete configmap spire-agent-config -n spire-agent --ignore-not-found=true
+echo -e "${COLOR_CYAN}[undeploy-spire-agent]${COLOR_RESET} Deleting ClusterRoleBinding and ClusterRole..."
 kubectl delete clusterrolebinding spire-agent-cluster-role-binding --ignore-not-found=true
 kubectl delete clusterrole spire-agent-cluster-role --ignore-not-found=true
+echo -e "${COLOR_CYAN}[undeploy-spire-agent]${COLOR_RESET} Deleting ServiceAccount..."
 kubectl delete serviceaccount spire-agent -n spire-agent --ignore-not-found=true
+echo -e "${COLOR_CYAN}[undeploy-spire-agent]${COLOR_RESET} Deleting Secret..."
 kubectl delete secret spire-bundle -n spire-agent --ignore-not-found=true
+echo -e "${COLOR_CYAN}[undeploy-spire-agent]${COLOR_RESET} Deleting namespace..."
 kubectl delete namespace spire-agent --ignore-not-found=true
 
-echo "[undeploy-spire-agent] SPIRE agent removed."
+echo ""
+echo -e "${COLOR_BRIGHT_GREEN}[undeploy-spire-agent]${COLOR_RESET} ${COLOR_BOLD}SPIRE agent removed.${COLOR_RESET}"

--- a/scripts/undeploy-spire-server.sh
+++ b/scripts/undeploy-spire-server.sh
@@ -1,30 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Source color support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/colors.sh"
+
 ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/artifacts/kubeconfig}"
 
 export KUBECONFIG="${KUBECONFIG_PATH}"
 
-echo "[undeploy] Removing SPIRE server..."
+echo -e "${COLOR_BRIGHT_BLUE}[undeploy]${COLOR_RESET} ${COLOR_BOLD}Removing SPIRE server...${COLOR_RESET}"
 if kubectl get namespace spire-server > /dev/null 2>&1; then
-	echo "[undeploy] Deleting StatefulSet..."
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting StatefulSet..."
 	kubectl delete statefulset spire-server -n spire-server --ignore-not-found=true
-	echo "[undeploy] Deleting Service..."
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting Service..."
 	kubectl delete service spire-server -n spire-server --ignore-not-found=true
-	echo "[undeploy] Deleting ConfigMap..."
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting ConfigMap..."
 	kubectl delete configmap spire-server-config -n spire-server --ignore-not-found=true
-	echo "[undeploy] Deleting Secrets..."
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting Secrets..."
 	kubectl delete secret spire-server-tls spire-server-ca spire-server-bootstrap -n spire-server --ignore-not-found=true
-	echo "[undeploy] Deleting ServiceAccount..."
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting ServiceAccount..."
 	kubectl delete serviceaccount spire-server -n spire-server --ignore-not-found=true
-	echo "[undeploy] Deleting ClusterRoleBinding and ClusterRole..."
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting ClusterRoleBinding and ClusterRole..."
 	kubectl delete clusterrolebinding spire-server-cluster-role-binding --ignore-not-found=true
 	kubectl delete clusterrole spire-server-cluster-role --ignore-not-found=true
-	echo "[undeploy] Deleting namespace..."
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting namespace..."
 	kubectl delete namespace spire-server --ignore-not-found=true
-	echo "[undeploy] SPIRE server removed successfully!"
+	echo ""
+	echo -e "${COLOR_BRIGHT_GREEN}[undeploy]${COLOR_RESET} ${COLOR_BOLD}SPIRE server removed successfully!${COLOR_RESET}"
 else
-	echo "[undeploy] Namespace 'spire-server' does not exist. Nothing to remove."
+	echo -e "${COLOR_YELLOW}[undeploy]${COLOR_RESET} Namespace '${COLOR_BOLD}spire-server${COLOR_RESET}' does not exist. Nothing to remove."
 fi
 


### PR DESCRIPTION
## Summary

This PR implements issue #12 and adds colorful output to all scripts for better user experience.

## Changes

### Issue #12 Implementation
- ✅ Added `make env-up` target that chains: tools → certs → cluster-up → deploy-spire-server → deploy-spire-agent → deploy-registration
- ✅ Added `make env-down` target that tears down: undeploy-registration → undeploy-spire-agent → undeploy-spire-server → cluster-down → clean
- ✅ Enhanced `make clean` to remove entire artifacts directory and binaries

### Color Support
- ✅ Created `scripts/colors.sh` shared library for consistent color definitions
- ✅ Added colorful output to all scripts:
  - `install-tools.sh` - Green checkmarks for found tools, red X for missing
  - `generate-certs.sh` - Colored progress and success indicators
  - `cluster-up.sh` - New script with colorful cluster setup messages
  - `deploy-spire-server.sh` - Colored deployment steps
  - `deploy-spire-agent.sh` - Colored progress with pod status
  - `deploy-registration.sh` - Colored registration steps
  - `undeploy-spire-server.sh` - Colored teardown steps
  - `undeploy-spire-agent.sh` - Colored teardown steps
  - `undeploy-registration.sh` - Colored cleanup steps
  - `check-spire-server.sh` - Added colors (previously had none)

### Color Schema
- **Bright Blue + Bold**: Main operation headers
- **Cyan**: Info messages, progress updates
- **Green (✓)**: Success indicators, completed operations
- **Yellow**: Warnings, skipped operations
- **Red (✗)**: Errors, failures
- **Bright Green + Bold**: Final completion messages

### Script Improvements
- Extracted `cluster-up` logic from Makefile into dedicated `scripts/cluster-up.sh` script
- All scripts now use consistent `[script-name]` prefix format
- Automatic TTY detection - colors only appear in terminals, not when piped

## Testing

- ✅ Verified `make env-up` brings clean repo to fully running environment
- ✅ Verified `make env-down` cleanly tears down all resources
- ✅ Verified all scripts provide consistent, colorful output
- ✅ Verified colors work correctly in terminal (disabled when piped)

## Related

Closes #12