### PR TITLE
Address spiffe-helper-rust issue 49

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ spiffe-helper-rust uses an HCL configuration file (default: `helper.conf`) to co
 
 ### Operation Modes
 
-spiffe-helper-rust supports two operation modes controlled by the `daemon_mode` configuration option:
+spiffe-helper-rust supports two operation modes controlled by the `daemon_mode` configuration option. **Daemon mode is the default** when `daemon_mode` is not specified.
 
-#### Daemon Mode (`daemon_mode = true`)
+#### Daemon Mode (`daemon_mode = true`, **default**)
 
-When `daemon_mode` is set to `true`, the program runs continuously until it receives a SIGTERM signal. This mode is suitable for sidecar containers that need to run alongside the main application:
+When `daemon_mode` is set to `true` (or not specified), the program runs continuously until it receives a SIGTERM signal. This mode is suitable for sidecar containers that need to run alongside the main application:
 
 - The program keeps running until SIGTERM is received
 - Periodic liveness logs are printed every 30 seconds to demonstrate the daemon is running
@@ -39,12 +39,18 @@ The mode can be set in two ways:
 
 1. **Via configuration file:**
    ```hcl
-   daemon_mode = true   # or false for one-shot mode
+   daemon_mode = true   # default, can be omitted
+   # or
+   daemon_mode = false  # for one-shot mode
    ```
+
+   **Note:** If `daemon_mode` is not specified, daemon mode is used by default.
 
 2. **Via command-line flag:**
    ```bash
    spiffe-helper-rust --daemon-mode true --config helper.conf
+   # or
+   spiffe-helper-rust --daemon-mode false --config helper.conf
    ```
 
    The command-line flag overrides the configuration file setting.
@@ -113,14 +119,17 @@ In daemon mode, the program responds to the following signals:
 
 ## Usage
 
-### Running in Daemon Mode
+### Running in Daemon Mode (Default)
 
 ```bash
-# Using configuration file
+# Using configuration file (daemon mode is the default)
 spiffe-helper-rust --config helper.conf
 
-# Overriding daemon_mode via command line
+# Explicitly enabling daemon mode via command line
 spiffe-helper-rust --config helper.conf --daemon-mode true
+
+# Running in one-shot mode (explicitly disable daemon mode)
+spiffe-helper-rust --config helper.conf --daemon-mode false
 
 # Stopping the daemon
 kill -TERM <pid>
@@ -130,7 +139,7 @@ kill -TERM <pid>
 
 ```hcl
 agent_address = "unix:///tmp/agent.sock"
-daemon_mode = true
+# daemon_mode = true  # Optional: daemon mode is the default
 cert_dir = "/etc/certs"
 
 health_checks {
@@ -140,6 +149,8 @@ health_checks {
     readiness_path = "/health/ready"
 }
 ```
+
+**Note:** The `daemon_mode` setting is optional. If omitted, daemon mode is used by default. To use one-shot mode, explicitly set `daemon_mode = false`.
 
 ## Integration Testing
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,8 +61,8 @@ async fn main() -> Result<()> {
         config.daemon_mode = Some(override_value);
     }
 
-    // Check if daemon mode is enabled
-    let daemon_mode = config.daemon_mode.unwrap_or(false);
+    // Check if daemon mode is enabled (defaults to true)
+    let daemon_mode = config.daemon_mode.unwrap_or(true);
     if !daemon_mode {
         // Non-daemon mode - fetch certificates once and exit
         run_once(config).await


### PR DESCRIPTION
Make daemon mode the default instead of one-shot mode.

This change aligns with the rationale in issue #49, as sidecar containers (daemon mode) are more common than initContainers in Kubernetes environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-08e767f6-e3b3-4769-ab8a-4fe9b59a0bdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08e767f6-e3b3-4769-ab8a-4fe9b59a0bdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

