### PR TITLE
fix: Ensure correct workload attestation in Kind cluster

### DIFF
--- a/deploy/spire/agent/clusterrole.yaml
+++ b/deploy/spire/agent/clusterrole.yaml
@@ -14,6 +14,9 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+  - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]
 

--- a/deploy/spire/agent/daemonset.yaml
+++ b/deploy/spire/agent/daemonset.yaml
@@ -16,6 +16,8 @@ spec:
     spec:
       serviceAccountName: spire-agent
       hostPID: true
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: spire-agent
         image: ghcr.io/spiffe/spire-agent:1.13.0

--- a/deploy/spire/server/deployment.yaml
+++ b/deploy/spire/server/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: spire-server
   namespace: spire-server
@@ -7,7 +7,6 @@ metadata:
     app: spire-server
     component: server
 spec:
-  serviceName: spire-server
   replicas: 1
   selector:
     matchLabels:
@@ -82,5 +81,3 @@ spec:
           secretName: spire-server-bootstrap
       - name: data
         emptyDir: {}
-  volumeClaimTemplates: []
-

--- a/scripts/deploy-spire-agent.sh
+++ b/scripts/deploy-spire-agent.sh
@@ -10,6 +10,8 @@ KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/artifacts/kubeconfig}"
 DEPLOY_DIR="${DEPLOY_DIR:-${ROOT_DIR}/deploy/spire/agent}"
 CERT_DIR="${CERT_DIR:-${ROOT_DIR}/artifacts/certs}"
 BOOTSTRAP_BUNDLE="${CERT_DIR}/bootstrap-bundle.pem"
+KIND="${KIND:-kind}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-spiffe-helper}"
 
 export KUBECONFIG="${KUBECONFIG_PATH}"
 

--- a/scripts/deploy-spire-server.sh
+++ b/scripts/deploy-spire-server.sh
@@ -9,6 +9,8 @@ ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/artifacts/kubeconfig}"
 DEPLOY_DIR="${DEPLOY_DIR:-${ROOT_DIR}/deploy/spire/server}"
 CERT_DIR="${CERT_DIR:-${ROOT_DIR}/artifacts/certs}"
+KIND="${KIND:-kind}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-spiffe-helper}"
 
 export KUBECONFIG="${KUBECONFIG_PATH}"
 
@@ -53,11 +55,11 @@ kubectl apply -f "${DEPLOY_DIR}/configmap.yaml"
 echo -e "${COLOR_CYAN}[deploy]${COLOR_RESET} Creating Service..."
 kubectl apply -f "${DEPLOY_DIR}/service.yaml"
 
-echo -e "${COLOR_CYAN}[deploy]${COLOR_RESET} Creating StatefulSet..."
-kubectl apply -f "${DEPLOY_DIR}/statefulset.yaml"
+echo -e "${COLOR_CYAN}[deploy]${COLOR_RESET} Creating Deployment..."
+kubectl apply -f "${DEPLOY_DIR}/deployment.yaml"
 
-echo -e "${COLOR_CYAN}[deploy]${COLOR_RESET} Waiting for StatefulSet rollout..."
-kubectl rollout status statefulset/spire-server -n spire-server --timeout=300s
+echo -e "${COLOR_CYAN}[deploy]${COLOR_RESET} Waiting for Deployment rollout..."
+kubectl rollout status deployment/spire-server -n spire-server --timeout=300s
 
 echo -e "${COLOR_CYAN}[deploy]${COLOR_RESET} Waiting for pod to be ready..."
 if ! kubectl wait --for=condition=ready pod -l app=spire-server -n spire-server --timeout=300s; then


### PR DESCRIPTION
fix the integration test kind cluster to make sure the workload attestation can be done correctly

Details:
- Enable `hostNetwork` for SPIRE Agent to communicate with Kubelet.
- Add `nodes/proxy` permission to SPIRE Agent ClusterRole.
- Switch to upstream images and remove debug build steps.
- Fix SPIRE Server storage issues by removing volume size limit.