### PR TITLE
Fix incorrect make file output (issue #57)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,6 @@ smoke-test: check-cluster
 .PHONY: env-up
 env-up: tools certs cluster-up deploy-spire-server deploy-spire-agent deploy-registration load-images
 	@echo "$(COLOR_BRIGHT_GREEN)[env-up]$(COLOR_RESET) $(COLOR_BOLD)Environment setup complete!$(COLOR_RESET)"
-	@echo "$(COLOR_CYAN)[env-up]$(COLOR_RESET) To deploy SPIRE CSI driver, run: $(COLOR_BOLD)make deploy-spire-csi$(COLOR_RESET)"
 
 .PHONY: env-down
 env-down: undeploy-registration undeploy-spire-agent undeploy-spire-server cluster-down clean


### PR DESCRIPTION
Fixes #57

Removes the misleading message about deploying SPIRE CSI driver from the `env-up` target in the Makefile. The CSI driver is not implemented, so the message was incorrect.

**Changes:**
- Removed the line that printed: `To deploy SPIRE CSI driver, run: make deploy-spire-csi` from the `env-up` target
- The `env-up` target now only prints the "Environment setup complete!" message