### PR TITLE
fix: add binary path to httpbin init container args

### DIFF
--- a/deploy/httpbin/httpbin.yaml
+++ b/deploy/httpbin/httpbin.yaml
@@ -41,6 +41,7 @@ spec:
         image: spiffe-helper-rust:test
         imagePullPolicy: Never
         args:
+        - /usr/local/bin/spiffe-helper-rust
         - --config
         - /etc/spiffe-helper/helper.conf
         volumeMounts:


### PR DESCRIPTION
## Problem
The httpbin deployment was failing with CrashLoopBackOff. The init container `spiffe-helper` was crashing with the error:
```
[dumb-init] --config: No such file or directory
```

## Root Cause
The Dockerfile uses `ENTRYPOINT ["dumb-init", "--"]` with `CMD ["/usr/local/bin/spiffe-helper-rust"]`. When Kubernetes `args` are specified, they replace the `CMD` from the Dockerfile. This caused `dumb-init` to try executing `--config` as a command instead of as an argument to the binary.

## Solution
Added `/usr/local/bin/spiffe-helper-rust` as the first argument in the init container args, so `dumb-init` can properly execute the binary with the `--config` flag and config file path.

## Testing
- ✅ Init container completes successfully (Exit Code: 0)
- ✅ Pod starts and runs with 2/2 containers ready
- ✅ httpbin service is accessible and responding correctly
- ✅ Cert directory is properly created and shared between containers

## Changes
- Updated `deploy/httpbin/httpbin.yaml` to include binary path in init container args