### PR TITLE
Fix httpbin image race condition and SPIRE socket path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ DEPLOY_REGISTRATION_SCRIPT := $(ROOT_DIR)/scripts/deploy-registration.sh
 UNDEPLOY_REGISTRATION_SCRIPT := $(ROOT_DIR)/scripts/undeploy-registration.sh
 DEPLOY_SPIRE_CSI_SCRIPT := $(ROOT_DIR)/scripts/deploy-spire-csi.sh
 UNDEPLOY_SPIRE_CSI_SCRIPT := $(ROOT_DIR)/scripts/undeploy-spire-csi.sh
+DEPLOY_HTTPBIN_SCRIPT := $(ROOT_DIR)/scripts/deploy-httpbin.sh
+UNDEPLOY_HTTPBIN_SCRIPT := $(ROOT_DIR)/scripts/undeploy-httpbin.sh
 SMOKE_TEST_SCRIPT := $(ROOT_DIR)/scripts/smoke-test.sh
 KIND ?= kind
 KIND_CLUSTER_NAME ?= spiffe-helper
@@ -163,17 +165,25 @@ deploy-spire-csi: check-cluster
 undeploy-spire-csi:
 	@$(UNDEPLOY_SPIRE_CSI_SCRIPT)
 
+.PHONY: deploy-httpbin
+deploy-httpbin: check-cluster
+	@$(DEPLOY_HTTPBIN_SCRIPT)
+
+.PHONY: undeploy-httpbin
+undeploy-httpbin:
+	@$(UNDEPLOY_HTTPBIN_SCRIPT)
+
 .PHONY: smoke-test
 smoke-test: check-cluster
 	@KUBECONFIG_PATH="$(KUBECONFIG_PATH)" ROOT_DIR="$(ROOT_DIR)" $(SMOKE_TEST_SCRIPT)
 
 # Top-level orchestration targets
 .PHONY: env-up
-env-up: tools certs cluster-up deploy-spire-server deploy-spire-agent deploy-registration load-images
+env-up: tools certs cluster-up deploy-spire-server deploy-spire-agent deploy-registration load-images deploy-httpbin
 	@echo "$(COLOR_BRIGHT_GREEN)[env-up]$(COLOR_RESET) $(COLOR_BOLD)Environment setup complete!$(COLOR_RESET)"
 
 .PHONY: env-down
-env-down: undeploy-registration undeploy-spire-agent undeploy-spire-server cluster-down clean
+env-down: undeploy-httpbin undeploy-registration undeploy-spire-agent undeploy-spire-server cluster-down clean
 	@echo "$(COLOR_BRIGHT_GREEN)[env-down]$(COLOR_RESET) $(COLOR_BOLD)Environment teardown complete!$(COLOR_RESET)"
 
 # Container image settings

--- a/deploy/httpbin/httpbin.yaml
+++ b/deploy/httpbin/httpbin.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: httpbin
 data:
   helper.conf: |
-    agent_address = "unix:///run/spire/sockets/workload_api.sock"
+    agent_address = "unix:///run/spire/sockets/agent.sock"
     daemon_mode = false
     cert_dir = "/tmp/certs"
 ---

--- a/scripts/cluster-up.sh
+++ b/scripts/cluster-up.sh
@@ -30,19 +30,5 @@ echo -e "${COLOR_CYAN}[cluster-up]${COLOR_RESET} Writing kubeconfig..."
 ${KIND} get kubeconfig --name "${KIND_CLUSTER_NAME}" > "${KUBECONFIG_PATH}"
 echo -e "${COLOR_GREEN}✓${COLOR_RESET} Kubeconfig written to ${COLOR_CYAN}${KUBECONFIG_PATH}${COLOR_RESET}"
 
-# Deploy httpbin service
-echo -e "${COLOR_CYAN}[cluster-up]${COLOR_RESET} Deploying httpbin service..."
-export KUBECONFIG="${KUBECONFIG_PATH}"
-if kubectl apply -f "${ROOT_DIR}/deploy/httpbin/httpbin.yaml" 2>/dev/null; then
-	echo -e "${COLOR_CYAN}[cluster-up]${COLOR_RESET} Waiting for httpbin pod to be ready..."
-	if kubectl wait --for=condition=ready pod -l app=httpbin -n httpbin --timeout=60s 2>/dev/null; then
-		echo -e "${COLOR_GREEN}✓${COLOR_RESET} httpbin pod is ready"
-	else
-		echo -e "${COLOR_YELLOW}[cluster-up]${COLOR_RESET} httpbin deployment may still be in progress"
-	fi
-else
-	echo -e "${COLOR_YELLOW}[cluster-up]${COLOR_RESET} Failed to deploy httpbin (may already exist)"
-fi
-
 echo ""
 echo -e "${COLOR_BRIGHT_GREEN}[cluster-up]${COLOR_RESET} ${COLOR_BOLD}Cluster setup complete!${COLOR_RESET}"

--- a/scripts/deploy-httpbin.sh
+++ b/scripts/deploy-httpbin.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source color support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/colors.sh"
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/artifacts/kubeconfig}"
+DEPLOY_DIR="${DEPLOY_DIR:-${ROOT_DIR}/deploy/httpbin}"
+
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+echo -e "${COLOR_BRIGHT_BLUE}[deploy]${COLOR_RESET} ${COLOR_BOLD}Deploying httpbin service...${COLOR_RESET}"
+
+if kubectl apply -f "${DEPLOY_DIR}/httpbin.yaml" 2>/dev/null; then
+	echo -e "${COLOR_CYAN}[deploy]${COLOR_RESET} Waiting for httpbin pod to be ready..."
+	if kubectl wait --for=condition=ready pod -l app=httpbin -n httpbin --timeout=60s 2>/dev/null; then
+		echo -e "${COLOR_GREEN}✓${COLOR_RESET} httpbin pod is ready"
+	else
+		echo -e "${COLOR_YELLOW}[deploy]${COLOR_RESET} httpbin deployment may still be in progress"
+	fi
+else
+	echo -e "${COLOR_YELLOW}[deploy]${COLOR_RESET} Failed to deploy httpbin (may already exist)"
+fi
+
+echo ""
+echo -e "${COLOR_BRIGHT_GREEN}[deploy]${COLOR_RESET} ${COLOR_BOLD}httpbin deployed successfully!${COLOR_RESET}"
+echo -e "${COLOR_CYAN}[deploy]${COLOR_RESET} Pod status:"
+kubectl get pods -n httpbin

--- a/scripts/undeploy-httpbin.sh
+++ b/scripts/undeploy-httpbin.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source color support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/colors.sh"
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/artifacts/kubeconfig}"
+
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+echo -e "${COLOR_BRIGHT_BLUE}[undeploy]${COLOR_RESET} ${COLOR_BOLD}Removing httpbin service...${COLOR_RESET}"
+if kubectl get namespace httpbin > /dev/null 2>&1; then
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting Deployment..."
+	kubectl delete deployment httpbin -n httpbin --ignore-not-found=true
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting Service..."
+	kubectl delete service httpbin -n httpbin --ignore-not-found=true
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting ConfigMap..."
+	kubectl delete configmap spiffe-helper-config -n httpbin --ignore-not-found=true
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting ServiceAccount..."
+	kubectl delete serviceaccount httpbin -n httpbin --ignore-not-found=true
+	echo -e "${COLOR_CYAN}[undeploy]${COLOR_RESET} Deleting namespace..."
+	kubectl delete namespace httpbin --ignore-not-found=true
+	echo ""
+	echo -e "${COLOR_BRIGHT_GREEN}[undeploy]${COLOR_RESET} ${COLOR_BOLD}httpbin removed successfully!${COLOR_RESET}"
+else
+	echo -e "${COLOR_YELLOW}[undeploy]${COLOR_RESET} Namespace '${COLOR_BOLD}httpbin${COLOR_RESET}' does not exist. Nothing to remove."
+fi


### PR DESCRIPTION
This PR fixes issue #70 by addressing two problems:

## Changes

1. **Fixed image race condition**: Moved httpbin deployment to run after images are loaded into the kind cluster. Previously, httpbin was deployed during cluster creation, causing `Init:ErrImageNeverPull` errors because the `spiffe-helper-rust:test` image wasn't available yet.

2. **Fixed SPIRE socket path**: Corrected the SPIRE agent socket path in httpbin configuration from `workload_api.sock` to `agent.sock` to match the actual SPIRE agent configuration.

## Implementation Details

- Extracted httpbin deployment logic from `scripts/cluster-up.sh` into separate `scripts/deploy-httpbin.sh` and `scripts/undeploy-httpbin.sh` scripts
- Updated `Makefile` to add `deploy-httpbin` and `undeploy-httpbin` targets
- Modified `env-up` workflow to deploy httpbin after images are loaded
- Updated `env-down` workflow to include httpbin cleanup
- Fixed socket path in `deploy/httpbin/httpbin.yaml`

## Testing

- ✅ `make env-up` completes successfully
- ✅ httpbin pod starts correctly with both containers ready (2/2 Running)
- ✅ Init container successfully fetches X.509 certificates from SPIRE agent
- ✅ `make smoke-test` passes all tests

Fixes #70