### PR TITLE
Implement SPIRE CSI Driver in test cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,11 +179,11 @@ smoke-test: check-cluster
 
 # Top-level orchestration targets
 .PHONY: env-up
-env-up: tools certs cluster-up deploy-spire-server deploy-spire-agent deploy-registration load-images deploy-httpbin
+env-up: tools certs cluster-up deploy-spire-server deploy-spire-agent deploy-spire-csi deploy-registration load-images deploy-httpbin
 	@echo "$(COLOR_BRIGHT_GREEN)[env-up]$(COLOR_RESET) $(COLOR_BOLD)Environment setup complete!$(COLOR_RESET)"
 
 .PHONY: env-down
-env-down: undeploy-httpbin undeploy-registration undeploy-spire-agent undeploy-spire-server cluster-down clean
+env-down: undeploy-httpbin undeploy-registration undeploy-spire-csi undeploy-spire-agent undeploy-spire-server cluster-down clean
 	@echo "$(COLOR_BRIGHT_GREEN)[env-down]$(COLOR_RESET) $(COLOR_BOLD)Environment teardown complete!$(COLOR_RESET)"
 
 # Container image settings

--- a/deploy/httpbin/httpbin.yaml
+++ b/deploy/httpbin/httpbin.yaml
@@ -89,9 +89,9 @@ spec:
           readOnly: true
       volumes:
       - name: spiffe-socket
-        hostPath:
-          path: /run/spire/sockets
-          type: DirectoryOrCreate
+        csi:
+          driver: "csi.spiffe.io"
+          readOnly: true
       - name: config
         configMap:
           name: spiffe-helper-config

--- a/deploy/spire/csi/clusterrole.yaml
+++ b/deploy/spire/csi/clusterrole.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-csi-driver
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]

--- a/deploy/spire/csi/clusterrolebinding.yaml
+++ b/deploy/spire/csi/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: spire-csi-driver
+    namespace: spire-agent
+roleRef:
+  kind: ClusterRole
+  name: spire-csi-driver
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/spire/csi/csidriver.yaml
+++ b/deploy/spire/csi/csidriver.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: "csi.spiffe.io"
+spec:
+  attachRequired: false
+  podInfoOnMount: true
+  fsGroupPolicy: None
+  volumeLifecycleModes:
+    - Ephemeral

--- a/deploy/spire/csi/daemonset.yaml
+++ b/deploy/spire/csi/daemonset.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: spire-csi-driver
+  namespace: spire-agent
+  labels:
+    app: spire-csi-driver
+spec:
+  selector:
+    matchLabels:
+      app: spire-csi-driver
+  template:
+    metadata:
+      labels:
+        app: spire-csi-driver
+    spec:
+      serviceAccountName: spire-csi-driver
+      containers:
+        - name: spire-csi-driver
+          image: ghcr.io/spiffe/spiffe-csi-driver:0.2.3
+          imagePullPolicy: IfNotPresent
+          args:
+            - -workload-api-socket-dir
+            - /spire-agent-socket
+            - -csi-socket-path
+            - /spiffe-csi/csi.sock
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: spire-agent-socket-dir
+              mountPath: /spire-agent-socket
+              readOnly: true
+            - name: spire-csi-socket-dir
+              mountPath: /spiffe-csi
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+          securityContext:
+            privileged: true
+        - name: node-driver-registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - -csi-address
+            - /spiffe-csi/csi.sock
+            - -kubelet-registration-path
+            - /var/lib/kubelet/plugins/csi.spiffe.io/csi.sock
+          volumeMounts:
+            - name: spire-csi-socket-dir
+              mountPath: /spiffe-csi
+            - name: kubelet-plugin-registration-dir
+              mountPath: /registration
+      volumes:
+        - name: spire-agent-socket-dir
+          hostPath:
+            path: /run/spire/sockets
+            type: DirectoryOrCreate
+        - name: spire-csi-socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.spiffe.io
+            type: DirectoryOrCreate
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        - name: kubelet-plugin-registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+      tolerations:
+        # Allow running on control-plane nodes
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule

--- a/deploy/spire/csi/serviceaccount.yaml
+++ b/deploy/spire/csi/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spire-csi-driver
+  namespace: spire-agent

--- a/scripts/deploy-spire-csi.sh
+++ b/scripts/deploy-spire-csi.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="${ROOT_DIR:-$(cd "${DIR}/.." && pwd)}"
+KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/artifacts/kubeconfig}"
+
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+echo "Deploying SPIRE CSI driver..."
+kubectl apply -f "${DIR}/../deploy/spire/csi/"
+echo "SPIRE CSI driver deployed."

--- a/scripts/undeploy-spire-csi.sh
+++ b/scripts/undeploy-spire-csi.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="${ROOT_DIR:-$(cd "${DIR}/.." && pwd)}"
+KUBECONFIG_PATH="${KUBECONFIG_PATH:-${ROOT_DIR}/artifacts/kubeconfig}"
+
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+echo "Undeploying SPIRE CSI driver..."
+kubectl delete -f "${DIR}/../deploy/spire/csi/" --ignore-not-found
+echo "SPIRE CSI driver undeployed."


### PR DESCRIPTION
## Summary
This PR implements the SPIRE CSI Driver for Kubernetes, replacing the `hostPath` volume mounting method for the SPIRE Agent socket. This enhances security and aligns with best practices for SPIFFE workload attestation.

## Changes
- **Added SPIRE CSI Driver Manifests**:
  - `deploy/spire/csi/csidriver.yaml`: Defines the `csi.spiffe.io` driver.
  - `deploy/spire/csi/daemonset.yaml`: Deploys the CSI driver and node-driver-registrar with necessary privileged security context and bidirectional mount propagation.
  - `deploy/spire/csi/rbac`: Added ServiceAccount, ClusterRole, and ClusterRoleBinding.
- **Added Deployment Scripts**:
  - `scripts/deploy-spire-csi.sh` & `scripts/undeploy-spire-csi.sh` for managing the CSI driver lifecycle.
- **Updated Makefile**:
  - Integrated `deploy-spire-csi` and `undeploy-spire-csi` into the `env-up` and `env-down` targets.
- **Updated Workload Configuration**:
  - Modified `deploy/httpbin/httpbin.yaml` to use the `csi.spiffe.io` driver for the `spiffe-socket` volume instead of `hostPath`.

## Test Plan
- Ran `make env-up` to spin up the full environment.
- Verified `spire-csi-driver` pods are running on all nodes.
- Verified `httpbin` pods (using CSI volume) start successfully and are in `Running` state.
- Confirmed SPIRE socket is accessible inside the workload container via `kubectl exec`.

Fixes #55