### PR TITLE
Fix clippy pedantic warnings across codebase

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -301,7 +301,7 @@ mod tests {
 
     fn parse_hcl_simple_value(hcl_str: &str) -> hcl::Value {
         // For simple values, wrap in a key-value pair and extract the value
-        let wrapped = format!("key = {}", hcl_str);
+        let wrapped = format!("key = {hcl_str}");
         let value = parse_hcl_value(&wrapped);
         if let hcl::Value::Object(obj) = value {
             obj.get("key").cloned().expect("key not found")
@@ -331,7 +331,7 @@ mod tests {
         let result = extract_string(&value).unwrap();
 
         // Assert
-        assert_eq!(result, Some("".to_string()));
+        assert_eq!(result, Some(String::new()));
     }
 
     #[test]
@@ -794,9 +794,9 @@ mod tests {
     #[test]
     fn test_extract_health_checks_disabled() {
         // Arrange
-        let hcl_str = r#"
+        let hcl_str = r"
             listener_enabled = false
-        "#;
+        ";
         let value = parse_hcl_value(hcl_str);
 
         // Act
@@ -843,10 +843,10 @@ mod tests {
     #[test]
     fn test_extract_health_checks_partial() {
         // Arrange
-        let hcl_str = r#"
+        let hcl_str = r"
             listener_enabled = true
             bind_port = 3000
-        "#;
+        ";
         let value = parse_hcl_value(hcl_str);
 
         // Act
@@ -864,8 +864,8 @@ mod tests {
     #[test]
     fn test_extract_health_checks_defaults() {
         // Arrange
-        let hcl_str = r#"
-        "#;
+        let hcl_str = r"
+        ";
         let value = parse_hcl_value(hcl_str);
 
         // Act
@@ -883,10 +883,10 @@ mod tests {
     #[test]
     fn test_extract_health_checks_invalid_port() {
         // Arrange
-        let hcl_str = r#"
+        let hcl_str = r"
             listener_enabled = true
             bind_port = 65536
-        "#;
+        ";
         let value = parse_hcl_value(hcl_str);
 
         // Act
@@ -954,8 +954,8 @@ mod tests {
     #[test]
     fn test_parse_hcl_value_to_config_empty() {
         // Arrange
-        let hcl_str = r#"
-        "#;
+        let hcl_str = r"
+        ";
         let value = parse_hcl_value(hcl_str);
 
         // Act

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ struct Args {
     #[arg(short, long, default_value = DEFAULT_CONFIG_FILE)]
     config: String,
 
-    /// Boolean true or false. Overrides daemon_mode in the config file.
+    /// Boolean true or false. Overrides `daemon_mode` in the config file.
     #[arg(long, value_enum)]
     daemon_mode: Option<DaemonModeFlag>,
 
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
 
     // Handle version flag
     if args.version {
-        println!("{}", VERSION);
+        println!("{VERSION}");
         return Ok(());
     }
 
@@ -64,12 +64,12 @@ async fn main() -> Result<()> {
 
     // Check if daemon mode is enabled (defaults to true)
     let daemon_mode = config.daemon_mode.unwrap_or(true);
-    if !daemon_mode {
-        // Non-daemon mode - fetch certificates once and exit
-        run_once(config).await
-    } else {
+    if daemon_mode {
         // Run daemon mode
         run_daemon(config).await
+    } else {
+        // Non-daemon mode - fetch certificates once and exit
+        run_once(config).await
     }
 }
 
@@ -83,7 +83,7 @@ async fn run_once(config: config::Config) -> Result<()> {
 
 /// Fetches the initial X.509 SVID from the SPIRE agent and writes it to the configured directory.
 ///
-/// This function validates the configuration (agent_address and cert_dir) and calls
+/// This function validates the configuration (`agent_address` and `cert_dir`) and calls
 /// `workload_api::fetch_and_write_x509_svid` to perform the actual fetch and write operation.
 /// It implements the shared initial SVID fetch policy used by both daemon and one-shot modes,
 /// including retry logic and backoff handling.
@@ -105,10 +105,7 @@ async fn fetch_x509_certificate(config: &config::Config) -> Result<()> {
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("cert_dir must be configured"))?;
 
-    println!(
-        "Fetching X.509 certificate from SPIRE agent at {}...",
-        agent_address
-    );
+    println!("Fetching X.509 certificate from SPIRE agent at {agent_address}...");
     let cert_dir_path = std::path::PathBuf::from(cert_dir);
     workload_api::fetch_and_write_x509_svid(
         agent_address,
@@ -118,10 +115,7 @@ async fn fetch_x509_certificate(config: &config::Config) -> Result<()> {
     )
     .await
     .with_context(|| "Failed to fetch X.509 certificate")?;
-    println!(
-        "Successfully fetched and wrote X.509 certificate to {}",
-        cert_dir
-    );
+    println!("Successfully fetched and wrote X.509 certificate to {cert_dir}");
     Ok(())
 }
 
@@ -146,9 +140,9 @@ async fn run_daemon(config: config::Config) -> Result<()> {
                 .clone()
                 .unwrap_or_else(|| "/health/ready".to_string());
 
-            println!("Starting health check server on {}", bind_addr);
-            println!("  Liveness path: {}", liveness_path);
-            println!("  Readiness path: {}", readiness_path);
+            println!("Starting health check server on {bind_addr}");
+            println!("  Liveness path: {liveness_path}");
+            println!("  Readiness path: {readiness_path}");
 
             let app = Router::new()
                 .route(&liveness_path, get(liveness_handler))
@@ -156,7 +150,7 @@ async fn run_daemon(config: config::Config) -> Result<()> {
 
             let listener = tokio::net::TcpListener::bind(&bind_addr)
                 .await
-                .with_context(|| format!("Failed to bind to {}", bind_addr))?;
+                .with_context(|| format!("Failed to bind to {bind_addr}"))?;
 
             Some(tokio::spawn(async move {
                 axum::serve(listener, app)
@@ -209,7 +203,7 @@ async fn run_daemon(config: config::Config) -> Result<()> {
                     }
                     Err(e) => {
                         // Task panicked or was cancelled
-                        break Err(anyhow::anyhow!("Health check server task failed: {}", e));
+                        break Err(anyhow::anyhow!("Health check server task failed: {e}"));
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Apply clippy pedantic lint fixes across src/main.rs, src/config.rs, and src/workload_api.rs
- Use inline format arguments (e.g., `format!("{var}")` instead of `format!("{}", var)`)
- Replace `"".to_string()` with `String::new()`
- Remove unnecessary raw string hashes (`r#"..."#` -> `r"..."`)
- Add backticks around code items in documentation
- Simplify if-else conditional order in daemon mode check

Fixes #78

## Test plan
- [x] All existing tests pass (60 tests)
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)