### PR TITLE
Unblocked issue processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,6 +1498,7 @@ dependencies = [
  "tonic",
  "tower 0.4.13",
  "tower-http",
+ "x509-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ spiffe = "0.4"
 pem = "1.1"
 tonic = "0.9"
 tokio-retry = "0.3.0"
+x509-parser = "0.15.1"
 
 [dev-dependencies]
 tempfile = "3.8"


### PR DESCRIPTION
Implement the `on_x509_update` callback and refactor X.509 SVID writing logic.

Resolves Issue #88 by enabling the daemon to handle and persist updated X.509 SVIDs, and fixes build dependency conflicts by downgrading several crates (`home`, `url`, `windows-sys`, `idna`).

---
<a href="https://cursor.com/background-agent?bcId=bc-6861c1b0-2806-4422-b40b-9a1977b3c605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6861c1b0-2806-4422-b40b-9a1977b3c605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

