### PR TITLE
Refactor X.509 write flow

### DIFF
--- a/spiffe-helper/src/daemon.rs
+++ b/spiffe-helper/src/daemon.rs
@@ -33,7 +33,7 @@ pub async fn run(source: X509Source, config: Config) -> Result<()> {
     let local_fs = LocalFileSystem::new(&config)?.ensure()?;
 
     // Initial fetch and write
-    fetch_and_process_update(&source, &local_fs, &config)?;
+    fetch_and_process_update(&source, &local_fs)?;
 
     // Spawn managed child process if configured
     let mut child = if let Some(cmd) = &config.cmd {
@@ -91,7 +91,7 @@ pub async fn run(source: X509Source, config: Config) -> Result<()> {
                 }
 
                 println!("Received X.509 update notification");
-                if let Err(e) = fetch_and_process_update(&source, &local_fs, &config) {
+                if let Err(e) = fetch_and_process_update(&source, &local_fs) {
                     eprintln!("Failed to handle X.509 update: {e}");
                     continue;
                 }
@@ -184,7 +184,6 @@ fn send_renew_signal(
 fn fetch_and_process_update(
     source: &X509Source,
     cert_writer: &impl crate::file_system::X509CertsWriter,
-    config: &Config,
 ) -> Result<()> {
     let svid = source
         .svid()
@@ -195,5 +194,5 @@ fn fetch_and_process_update(
         .map_err(|e| anyhow::anyhow!("Failed to get bundle: {e}"))?
         .ok_or_else(|| anyhow::anyhow!("No bundle received"))?;
 
-    workload_api::write_x509_svid_on_update(&svid, &bundle, cert_writer, config)
+    workload_api::write_x509_svid_on_update(&svid, &bundle, cert_writer)
 }

--- a/spiffe-helper/src/oneshot.rs
+++ b/spiffe-helper/src/oneshot.rs
@@ -21,7 +21,7 @@ pub async fn run(source: X509Source, config: Config) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to get bundle: {e}"))?
         .ok_or_else(|| anyhow::anyhow!("No bundle received"))?;
 
-    workload_api::write_x509_svid_on_update(&svid, &bundle, &local_fs, &config)?;
+    workload_api::write_x509_svid_on_update(&svid, &bundle, &local_fs)?;
 
     println!("Successfully fetched and wrote X.509 certificate to {cert_dir}");
     println!("One-shot mode complete");

--- a/spiffe-helper/src/oneshot.rs
+++ b/spiffe-helper/src/oneshot.rs
@@ -12,10 +12,9 @@ pub async fn run(source: X509Source, config: Config) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("cert_dir must be configured"))?;
 
     let local_fs = LocalFileSystem::new(&config)?.ensure()?;
-    let svid = (*source
+    let svid = source
         .svid()
-        .map_err(|e| anyhow::anyhow!("Failed to fetch X.509 certificate: {e}"))?)
-    .clone();
+        .map_err(|e| anyhow::anyhow!("Failed to fetch X.509 certificate: {e}"))?;
     let bundle = source
         .bundle_for_trust_domain(svid.spiffe_id().trust_domain())
         .map_err(|e| anyhow::anyhow!("Failed to get bundle: {e}"))?

--- a/spiffe-helper/src/workload_api.rs
+++ b/spiffe-helper/src/workload_api.rs
@@ -41,7 +41,7 @@ pub fn write_x509_svid_on_update<S: X509CertsWriter>(
 
     cert_writer.write_certs(svid.cert_chain())?;
     cert_writer.write_key(svid.private_key().as_ref())?;
-    cert_writer.write_bundle(bundle, config.svid_bundle_file_name())?;
+    cert_writer.write_bundle(bundle)?;
 
     // Log update with SPIFFE ID and certificate expiry
     println!(
@@ -157,7 +157,7 @@ fPfrHw1nYcPliVB4Zbv8d1w=
             Ok(())
         }
 
-        fn write_bundle(&self, _bundle: &X509Bundle, _bundle_file_name: &str) -> Result<()> {
+        fn write_bundle(&self, _bundle: &X509Bundle) -> Result<()> {
             Ok(())
         }
     }
@@ -214,12 +214,13 @@ fPfrHw1nYcPliVB4Zbv8d1w=
         let bundle = get_test_bundle();
         let config = Config {
             cert_dir: Some(cert_dir.to_str().unwrap().to_string()),
+            svid_bundle_file_name: Some("bundle.pem".to_string()),
             ..Default::default()
         };
 
         let local_fs = LocalFileSystem::new(&config).unwrap().ensure().unwrap();
         local_fs
-            .write_bundle(&bundle, "bundle.pem")
+            .write_bundle(&bundle)
             .expect("Failed to write bundle");
 
         assert!(cert_dir.join("bundle.pem").exists());


### PR DESCRIPTION
## Summary
- Extract shared X.509 fetch+write flow into workload_api
- Introduce X509CertsWriter/LocalFileSystem bundle handling and simplify call sites
- Reduce duplication in oneshot and daemon paths

## Testing
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings