### PR TITLE
Add comment for X.509 cert chain handling

### DIFF
--- a/spiffe-helper/src/workload_api.rs
+++ b/spiffe-helper/src/workload_api.rs
@@ -49,6 +49,8 @@ pub fn write_x509_svid_on_update<S: X509CertsWriter>(
     bundle: &X509Bundle,
     cert_writer: &S,
 ) -> Result<()> {
+    // The chain includes intermediates; writing all certs into one PEM file
+    // preserves the full path needed for TLS validation.
     cert_writer.write_certs(svid.cert_chain())?;
     cert_writer.write_key(svid.private_key().as_ref())?;
     cert_writer.write_bundle(bundle)?;


### PR DESCRIPTION
## Summary
- document that the SVID cert chain includes intermediates and is written as a single PEM

## Testing
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build
- cargo test

Fixes #46