### PR TITLE
Refactor filesystem config resolution

### DIFF
--- a/spiffe-helper/src/cli/mod.rs
+++ b/spiffe-helper/src/cli/mod.rs
@@ -3,5 +3,5 @@ pub mod config;
 pub mod health_check;
 
 pub use args::{Args, DEFAULT_CONFIG_FILE};
-pub use config::{parse_hcl_config, Config, JwtSvid};
+pub use config::{parse_hcl_config, Config, JwtSvid, ResolvedFileSystemConfig};
 pub use health_check::HealthChecks;

--- a/spiffe-helper/src/daemon.rs
+++ b/spiffe-helper/src/daemon.rs
@@ -26,7 +26,8 @@ pub async fn run(source: X509Source, config: Config) -> Result<()> {
 
     println!("Connected to SPIRE agent");
 
-    let local_fs = LocalFileSystem::new(&config)?.ensure()?;
+    let file_system_config = config.resolve_file_system_config()?;
+    let local_fs = LocalFileSystem::new(file_system_config).ensure()?;
 
     // Initial fetch and write
     workload_api::fetch_and_write_x509_svid(&source, &local_fs)?;

--- a/spiffe-helper/src/oneshot.rs
+++ b/spiffe-helper/src/oneshot.rs
@@ -10,7 +10,8 @@ pub async fn run(source: X509Source, config: Config) -> Result<()> {
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("cert_dir must be configured"))?;
 
-    let local_fs = LocalFileSystem::new(&config)?.ensure()?;
+    let file_system_config = config.resolve_file_system_config()?;
+    let local_fs = LocalFileSystem::new(file_system_config).ensure()?;
     workload_api::fetch_and_write_x509_svid(&source, &local_fs)?;
 
     println!("Successfully fetched and wrote X.509 certificate to {cert_dir}");

--- a/spiffe-helper/src/workload_api.rs
+++ b/spiffe-helper/src/workload_api.rs
@@ -206,7 +206,8 @@ fPfrHw1nYcPliVB4Zbv8d1w=
             svid_key_file_name: Some("svid_key.pem".to_string()),
             ..Default::default()
         };
-        let local_fs = LocalFileSystem::new(&config).unwrap().ensure().unwrap();
+        let file_system_config = config.resolve_file_system_config().unwrap();
+        let local_fs = LocalFileSystem::new(file_system_config).ensure().unwrap();
 
         local_fs.write_certs(svid.cert_chain()).unwrap();
         local_fs.write_key(svid.private_key().as_ref()).unwrap();
@@ -231,7 +232,8 @@ fPfrHw1nYcPliVB4Zbv8d1w=
             ..Default::default()
         };
 
-        let local_fs = LocalFileSystem::new(&config).unwrap().ensure().unwrap();
+        let file_system_config = config.resolve_file_system_config().unwrap();
+        let local_fs = LocalFileSystem::new(file_system_config).ensure().unwrap();
         local_fs
             .write_bundle(&bundle)
             .expect("Failed to write bundle");
@@ -256,7 +258,8 @@ fPfrHw1nYcPliVB4Zbv8d1w=
         let svid = get_test_svid();
         let bundle = get_test_bundle();
 
-        let local_fs = LocalFileSystem::new(&config).unwrap().ensure().unwrap();
+        let file_system_config = config.resolve_file_system_config().unwrap();
+        let local_fs = LocalFileSystem::new(file_system_config).ensure().unwrap();
         let result = write_x509_svid_on_update(&svid, &bundle, &local_fs);
         assert!(result.is_ok());
 


### PR DESCRIPTION
## Summary
- introduce resolved filesystem settings to decouple LocalFileSystem from CLI config
- resolve output paths/modes in Config before constructing filesystem writers
- update daemon/one-shot flows and tests to use the resolved config